### PR TITLE
Remove duplicate `#!/bin/bash` runline [skip ci]

### DIFF
--- a/pkg/oc/update.sh
+++ b/pkg/oc/update.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
-
 # Hack to ensure that if we are running on OS X with a homebrew installed
 # GNU sed then we can still run sed.
 runsed() {


### PR DESCRIPTION
This probably happened by adding a license block at the top of the file,
with a second `#!/bin/bash` runline, on top of an existing one.