### PR TITLE
Use autogen v0.4 explicitly for stability

### DIFF
--- a/pkg/oc/update.sh
+++ b/pkg/oc/update.sh
@@ -25,7 +25,6 @@ runsed() {
 }
 
 git clone https://github.com/openconfig/public.git
-git clone https://github.com/mbrukman/autogen.git
 mkdir deps && cp ../../third_party/*.yang deps
 go run $GOPATH/src/github.com/openconfig/ygot/generator/generator.go -path=public,deps -output_file=oc.go \
   -package_name=oc -generate_fakeroot -fakeroot_name=lsdb -compress_paths=true \
@@ -34,5 +33,6 @@ go run $GOPATH/src/github.com/openconfig/ygot/generator/generator.go -path=publi
   -generate_append \
   yang/lsdbparse-isis.yang
 gofmt -w -s oc.go
+git clone -b v0.4 https://github.com/mbrukman/autogen.git
 autogen/autogen --no-code --no-tlc -c "Google LLC" -l apache -i oc.go
 rm -rf public autogen deps


### PR DESCRIPTION
Also moved the checkout line closer to where it's used.

This script was using the latest version of autogen, which
I am planning to rewrite in the future to be written in Go,
at which point what is you're doing here will not work.

Keeping the checkout to be fixed to a specific version will
enable you to not be broken, and to switch this to the new
form when you're ready.